### PR TITLE
Disable capturing layers with an `alpha` of 0

### DIFF
--- a/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
+++ b/FBSnapshotTestCase/Categories/UIImage+Snapshot.m
@@ -17,7 +17,7 @@
     NSAssert1(CGRectGetWidth(bounds), @"Zero width for layer %@", layer);
     NSAssert1(CGRectGetHeight(bounds), @"Zero height for layer %@", layer);
 
-    UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
+    UIGraphicsBeginImageContextWithOptions(bounds.size, YES, 0);
     CGContextRef context = UIGraphicsGetCurrentContext();
     NSAssert1(context, @"Could not generate context for layer %@", layer);
     CGContextSaveGState(context);


### PR DESCRIPTION
Disables capturing transparent layers in snapshots. These layers
can confuse tests, leading to image diffs with no
perceptible difference

Ticket that inspired this change: https://github.com/uber/ios-snapshot-test-case/issues/120