### PR TITLE
Adds flat directory support to snapshot testing

### DIFF
--- a/FBSnapshotTestCase/FBSnapshotTestCase.h
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.h
@@ -158,6 +158,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readwrite, nonatomic, copy, nullable) NSString *folderName;
 
 /**
+ Flattens the resulting filename with the following pattern TestCase_TestName_filename.png
+
+ @attention This property *must* be called *AFTER* [super setUp].
+ */
+@property (readwrite, nonatomic, assign) BOOL flattenSnapshotFilename;
+
+/**
  When YES, renders a snapshot of the complete view hierarchy as visible onscreen.
  There are several things that do not work if renderInContext: is used.
  - UIVisualEffect #70

--- a/FBSnapshotTestCase/FBSnapshotTestCase.m
+++ b/FBSnapshotTestCase/FBSnapshotTestCase.m
@@ -71,6 +71,16 @@
     _snapshotController.folderName = folderName;
 }
 
+- (BOOL)flattenSnapshotFilename
+{
+    return _snapshotController.flattenSnapshotFilename;
+}
+
+- (void)setFlattenSnapshotFilename:(BOOL)enabled
+{
+    _snapshotController.flattenSnapshotFilename = enabled;
+}
+
 #pragma mark - Public API
 
 - (NSString *)snapshotVerifyViewOrLayer:(id)viewOrLayer

--- a/FBSnapshotTestCase/FBSnapshotTestController.h
+++ b/FBSnapshotTestCase/FBSnapshotTestController.h
@@ -93,6 +93,11 @@ extern NSString *const FBDiffedImageKey;
 @property (readwrite, nonatomic, copy) NSString *folderName;
 
 /**
+ Flattens the resulting filename with the following pattern TestCase_TestName_filename.png
+ */
+@property (readwrite, nonatomic, assign) BOOL flattenSnapshotFilename;
+
+/**
  @param testClass The subclass of FBSnapshotTestCase that is using this controller.
  @returns An instance of FBSnapshotTestController.
  */

--- a/FBSnapshotTestCase/FBSnapshotTestController.m
+++ b/FBSnapshotTestCase/FBSnapshotTestController.m
@@ -291,9 +291,14 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
     NSString *fileName = [self _fileNameForSelector:selector
                                          identifier:identifier
                                        fileNameType:FBTestSnapshotFileNameTypeReference];
-    NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:self.folderName];
-    filePath = [filePath stringByAppendingPathComponent:fileName];
-    return filePath;
+    if (self.flattenSnapshotFilename) {
+        NSString *formattedFilename = [NSString stringWithFormat:@"%@_%@", self.folderName, fileName];
+        return [_referenceImagesDirectory stringByAppendingPathComponent:formattedFilename];
+    } else {
+        NSString *filePath = [_referenceImagesDirectory stringByAppendingPathComponent:self.folderName];
+        filePath = [filePath stringByAppendingPathComponent:fileName];
+        return filePath;
+    }
 }
 
 - (NSString *)_failedFilePathForSelector:(SEL)selector
@@ -304,9 +309,14 @@ typedef NS_ENUM(NSUInteger, FBTestSnapshotFileNameType) {
                                          identifier:identifier
                                        fileNameType:fileNameType];
 
-    NSString *filePath = [_imageDiffDirectory stringByAppendingPathComponent:self.folderName];
-    filePath = [filePath stringByAppendingPathComponent:fileName];
-    return filePath;
+    if (self.flattenSnapshotFilename) {
+        NSString *formattedFilename = [NSString stringWithFormat:@"%@_%@", self.folderName, fileName];
+        return [_imageDiffDirectory stringByAppendingPathComponent:formattedFilename];
+    } else {
+        NSString *filePath = [_imageDiffDirectory stringByAppendingPathComponent:self.folderName];
+        filePath = [filePath stringByAppendingPathComponent:fileName];
+        return filePath;
+    }
 }
 
 - (BOOL)_performPixelComparisonWithViewOrLayer:(id)viewOrLayer


### PR DESCRIPTION
Allows developers to flatten the output structure with fully qualified
filenames for each snapshot, scoped by TestCase_TestName_Filename

This support is needed to support Bazel remote execution as it does not
copy the full directory structure into the xctest bundle, therefore we
need these fully qualified names to avoid collisions